### PR TITLE
Add stress test for pg_buffercache during shared buffer resizing

### DIFF
--- a/contrib/pg_buffercache/Makefile
+++ b/contrib/pg_buffercache/Makefile
@@ -12,7 +12,8 @@ DATA = pg_buffercache--1.2.sql pg_buffercache--1.2--1.3.sql \
 	pg_buffercache--1.5--1.6.sql pg_buffercache--1.6--1.7.sql
 PGFILEDESC = "pg_buffercache - monitoring of shared buffer cache in real-time"
 
-REGRESS = pg_buffercache pg_buffercache_numa
+# REGRESS = pg_buffercache pg_buffercache_numa
+TAP_TESTS = 1
 
 ifdef USE_PGXS
 PG_CONFIG = pg_config

--- a/contrib/pg_buffercache/Makefile
+++ b/contrib/pg_buffercache/Makefile
@@ -12,7 +12,7 @@ DATA = pg_buffercache--1.2.sql pg_buffercache--1.2--1.3.sql \
 	pg_buffercache--1.5--1.6.sql pg_buffercache--1.6--1.7.sql
 PGFILEDESC = "pg_buffercache - monitoring of shared buffer cache in real-time"
 
-# REGRESS = pg_buffercache pg_buffercache_numa
+REGRESS = pg_buffercache pg_buffercache_numa
 TAP_TESTS = 1
 
 ifdef USE_PGXS

--- a/contrib/pg_buffercache/meson.build
+++ b/contrib/pg_buffercache/meson.build
@@ -38,13 +38,10 @@ tests += {
       'pg_buffercache',
       'pg_buffercache_numa',
     ],
-   },
+  },
   'tap': {
-    'env': {
-      'enable_injection_points': get_option('injection_points') ? 'yes' : 'no',
-    },
     'tests': [
       't/001_stress.pl',
     ],
-   }
+  },
 }

--- a/contrib/pg_buffercache/meson.build
+++ b/contrib/pg_buffercache/meson.build
@@ -38,5 +38,13 @@ tests += {
       'pg_buffercache',
       'pg_buffercache_numa',
     ],
-  },
+   },
+  'tap': {
+    'env': {
+      'enable_injection_points': get_option('injection_points') ? 'yes' : 'no',
+    },
+    'tests': [
+      't/001_stress.pl',
+    ],
+   }
 }

--- a/contrib/pg_buffercache/sql/buffercache_scan.sql
+++ b/contrib/pg_buffercache/sql/buffercache_scan.sql
@@ -1,1 +1,0 @@
-SELECT count(*) FROM pg_buffercache;

--- a/contrib/pg_buffercache/sql/buffercache_scan.sql
+++ b/contrib/pg_buffercache/sql/buffercache_scan.sql
@@ -1,0 +1,1 @@
+SELECT count(*) FROM pg_buffercache;

--- a/contrib/pg_buffercache/t/001_stress.pl
+++ b/contrib/pg_buffercache/t/001_stress.pl
@@ -10,6 +10,7 @@ use Test::More;
 my $node = PostgreSQL::Test::Cluster->new('stress');
 $node->init;
 
+# Sizes in 8kB blocks. restart_after_crash = off to fail hard on crashes.
 $node->append_conf('postgresql.conf', qq{
 max_shared_buffers = 160
 shared_buffers = 16
@@ -28,26 +29,34 @@ $node->pgbench(
 	 qr{done in \d+\.\d\d s }],
 	"pgbench init");
 
+# Long-lived backends (no -C) stress re-attach to resized shmem mid-query.
+# Concurrent resizes serialize internally; losers return false, not asserted.
 $node->pgbench(
-	'--no-vacuum --client=10 --transactions=500 -C '
-	  . '-b tpcb-like@5',
+	'--no-vacuum --client=10 --transactions=200 -b tpcb-like@5',
 	0,
 	[qr{actually processed}],
 	[qr{^$}],
 	'concurrent writes, scans, and resizes',
 	{
-		'buffercache_scan@10' => q{
-			SELECT count(*) FROM pg_buffercache;
-		},
-		# Sleep lets the config reload propagate before the resize.
+		'buffercache_scan@10' => q{SELECT count(*) FROM pg_buffercache},
+		# Range spans [shared_buffers, max_shared_buffers] so both bounds
+		# are exercised.  pg_sleep() is a CheckForInterrupts point that
+		# lets SIGHUP from pg_reload_conf() land in this backend before
+		# pg_resize_shared_buffers() reads the new GUC value.
 		'resize@2' => q{
-			\set nbuf random(16, 150)
+			\set nbuf random(20, 160)
 			ALTER SYSTEM SET shared_buffers = :nbuf;
 			SELECT pg_reload_conf();
 			SELECT pg_sleep(0.01);
 			SELECT pg_resize_shared_buffers();
 		},
 	});
+
+# Confirm at least one in-workload resize actually landed: the running
+# shared_buffers must have moved away from the initial 16 blocks (128kB).
+isnt($node->safe_psql('postgres', "SHOW shared_buffers"),
+	'128kB',
+	'at least one concurrent resize succeeded');
 
 # Resize to a known final size and verify.
 my $final_buffers = 24;
@@ -67,9 +76,11 @@ is($node->safe_psql('postgres', "SELECT count(*) FROM pg_buffercache"),
 	$final_buffers,
 	"pg_buffercache count matches final size ($final_buffers buffers)");
 
+# pgbench --scale=1 populates pgbench_accounts with 100000 rows; the tpcb-like
+# workload only updates rows, so the count must be preserved exactly.
 my $rows = $node->safe_psql('postgres',
 	"SELECT count(*) FROM pgbench_accounts");
-cmp_ok($rows, '>', 0, "pgbench_accounts still readable after stress");
+is($rows, '100000', "pgbench_accounts row count preserved after stress");
 
 $node->connect_ok("dbname=postgres",
 	"database accessible after stress test");

--- a/contrib/pg_buffercache/t/001_stress.pl
+++ b/contrib/pg_buffercache/t/001_stress.pl
@@ -1,7 +1,17 @@
-# Copyright (c) 2025-2025, PostgreSQL Global Development Group
+# Copyright (c) 2025-2026, PostgreSQL Global Development Group
 #
 # Stress test for pg_buffercache scans during concurrent shared buffer
 # pool resizing.
+#
+# Runs three concurrent pgbench workloads:
+#   - tpcb-like (weight 5): write-heavy TPC-B generating dirty buffers / WAL
+#   - buffercache_scan (weight 10): SELECT count(*) FROM pg_buffercache
+#   - resize (weight 2): randomly resize the buffer pool between 16 and 150
+#     buffers (128 kB – 1200 kB) via pg_resize_shared_buffers()
+#
+# After the concurrent phase, the pool is resized to a known size and
+# post-stress sanity checks verify the buffer count, data readability,
+# and connectivity.
 
 use strict;
 use warnings;
@@ -11,6 +21,10 @@ use Test::More;
 my $node = PostgreSQL::Test::Cluster->new('stress');
 $node->init;
 
+# max_shared_buffers = 160 (upper bound for dynamic resizing, in 8kB blocks).
+# shared_buffers = 16 (start small so the first resizes grow the pool).
+# restart_after_crash = off so a crash causes the test to fail rather than
+# silently recovering.
 $node->append_conf('postgresql.conf', qq{
 max_shared_buffers = 160
 shared_buffers = 16
@@ -29,6 +43,8 @@ $node->pgbench(
 	 qr{done in \d+\.\d\d s }],
 	"pgbench init");
 
+# 10 clients x 500 transactions, -C reconnects each transaction.
+# Script weights: tpcb-like@5, buffercache_scan@10, resize@2.
 $node->pgbench(
 	'--no-vacuum --client=10 --transactions=500 -C '
 	  . '-b tpcb-like@5',
@@ -40,6 +56,9 @@ $node->pgbench(
 		'buffercache_scan@10' => q{
 			SELECT count(*) FROM pg_buffercache;
 		},
+		# :nbuf is in 8kB blocks (the default unit for shared_buffers).
+		# The short sleep lets the config reload propagate before we
+		# attempt the actual resize.
 		'resize@2' => q{
 			\set nbuf random(16, 150)
 			ALTER SYSTEM SET shared_buffers = :nbuf;
@@ -49,6 +68,7 @@ $node->pgbench(
 		},
 	});
 
+# Resize to a known final size and verify.
 my $final_buffers = 24;
 my $final_size = ($final_buffers * 8) . 'kB';
 $node->safe_psql('postgres',
@@ -73,4 +93,5 @@ cmp_ok($rows, '>', 0, "pgbench_accounts still readable after stress");
 $node->connect_ok("dbname=postgres",
 	"database accessible after stress test");
 
+$node->stop;
 done_testing();

--- a/contrib/pg_buffercache/t/001_stress.pl
+++ b/contrib/pg_buffercache/t/001_stress.pl
@@ -1,17 +1,6 @@
 # Copyright (c) 2025-2026, PostgreSQL Global Development Group
 #
-# Stress test for pg_buffercache scans during concurrent shared buffer
-# pool resizing.
-#
-# Runs three concurrent pgbench workloads:
-#   - tpcb-like (weight 5): write-heavy TPC-B generating dirty buffers / WAL
-#   - buffercache_scan (weight 10): SELECT count(*) FROM pg_buffercache
-#   - resize (weight 2): randomly resize the buffer pool between 16 and 150
-#     buffers (128 kB – 1200 kB) via pg_resize_shared_buffers()
-#
-# After the concurrent phase, the pool is resized to a known size and
-# post-stress sanity checks verify the buffer count, data readability,
-# and connectivity.
+# Stress test: pg_buffercache scans during concurrent buffer pool resizing.
 
 use strict;
 use warnings;
@@ -21,10 +10,6 @@ use Test::More;
 my $node = PostgreSQL::Test::Cluster->new('stress');
 $node->init;
 
-# max_shared_buffers = 160 (upper bound for dynamic resizing, in 8kB blocks).
-# shared_buffers = 16 (start small so the first resizes grow the pool).
-# restart_after_crash = off so a crash causes the test to fail rather than
-# silently recovering.
 $node->append_conf('postgresql.conf', qq{
 max_shared_buffers = 160
 shared_buffers = 16
@@ -43,8 +28,6 @@ $node->pgbench(
 	 qr{done in \d+\.\d\d s }],
 	"pgbench init");
 
-# 10 clients x 500 transactions, -C reconnects each transaction.
-# Script weights: tpcb-like@5, buffercache_scan@10, resize@2.
 $node->pgbench(
 	'--no-vacuum --client=10 --transactions=500 -C '
 	  . '-b tpcb-like@5',
@@ -56,9 +39,7 @@ $node->pgbench(
 		'buffercache_scan@10' => q{
 			SELECT count(*) FROM pg_buffercache;
 		},
-		# :nbuf is in 8kB blocks (the default unit for shared_buffers).
-		# The short sleep lets the config reload propagate before we
-		# attempt the actual resize.
+		# Sleep lets the config reload propagate before the resize.
 		'resize@2' => q{
 			\set nbuf random(16, 150)
 			ALTER SYSTEM SET shared_buffers = :nbuf;

--- a/contrib/pg_buffercache/t/001_stress.pl
+++ b/contrib/pg_buffercache/t/001_stress.pl
@@ -1,0 +1,179 @@
+# Copyright (c) 2025-2025, PostgreSQL Global Development Group
+#
+# Stress test for shared_buffer resizing under concurrent read and write load.
+# Runs pgbench TPC-B (writes) and pg_buffercache scans (reads) while resizing
+# the buffer pool through a range of sizes including near the maximum.
+
+use strict;
+use warnings;
+use File::Basename;
+use IPC::Run;
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Test::More;
+
+# Function to resize buffer pool and verify the change.
+sub apply_and_verify_buffer_change
+{
+	my ($node, $new_size) = @_;
+	
+	# Use the new pg_resize_shared_buffers() interface which handles everything synchronously
+	$node->safe_psql('postgres', "ALTER SYSTEM SET shared_buffers = '$new_size'");
+	$node->safe_psql('postgres', "SELECT pg_reload_conf()");
+	
+	# If resize function fails, try a few times before giving up
+	my $max_retries = 5;
+	my $retry_delay = 1; # seconds
+	my $success = 0;
+	for my $attempt (1..$max_retries) {
+		my $result = $node->safe_psql('postgres', "SELECT pg_resize_shared_buffers()");
+		if ($result eq 't') {
+			$success = 1;
+			last;
+		}
+		
+		# If not the last attempt, wait before retrying
+		if ($attempt < $max_retries) {
+			note "Resizing buffer pool to $new_size, attempt $attempt failed, retrying after $retry_delay seconds...";
+			sleep($retry_delay);
+		}
+	}
+	
+	is($success, 1, 'resizing to ' . $new_size . ' succeeded after retries');
+	is($node->safe_psql('postgres', "SHOW shared_buffers"), $new_size,
+		'SHOW after resizing to '. $new_size . ' succeeded');
+}
+
+# Initialize a cluster and start pgbench in the background for concurrent load.
+my $node = PostgreSQL::Test::Cluster->new('main');
+$node->init;
+
+# Permit resizing up to 160 buffers (1280kB) and start with 16 buffers (128kB).
+$node->append_conf('postgresql.conf', qq{
+max_shared_buffers = 160
+shared_buffers = 16
+log_statement = none
+});
+
+$node->start;
+$node->safe_psql('postgres', "CREATE EXTENSION pg_buffercache");
+my $pgb_scale = 1;
+my $pgb_duration = 40;
+my $pgb_num_clients = 3;
+$node->pgbench(
+	"--initialize --init-steps=dtpvg --scale=$pgb_scale --quiet",
+	0,
+	[qr{^$}],
+	[   # stderr patterns to verify initialization stages
+		qr{dropping old tables},
+		qr{creating tables},
+		qr{done in \d+\.\d\d s }
+	],
+	"pgbench initialization (scale=$pgb_scale)"
+);
+
+# Start pgbench with default TPC-B workload for write-heavy load (dirty buffers,
+# WAL, checkpointing).  Use -C to create new connections during resize and
+# --exit-on-abort to stop on server crash.
+my ($write_stdin, $write_stdout, $write_stderr) = ('', '', '');
+my $write_process = IPC::Run::start(
+	[
+		'pgbench',
+		'-p', $node->port,
+		'-T', $pgb_duration,
+		'-c', $pgb_num_clients,
+		'-C',
+		'--exit-on-abort',
+		'postgres'
+	],
+	'<'  => \$write_stdin,
+	'>'  => \$write_stdout,
+	'2>' => \$write_stderr
+);
+ok($write_process, "pgbench TPC-B (write) started successfully");
+
+# Start a second pgbench with pg_buffercache scans for read-only load that
+# exercises the buffer descriptor array during resize.
+my ($scan_stdin, $scan_stdout, $scan_stderr) = ('', '', '');
+my $script_file = dirname(__FILE__) . '/../sql/buffercache_scan.sql';
+my $scan_process = IPC::Run::start(
+	[
+		'pgbench',
+		'-p', $node->port,
+		'-T', $pgb_duration,
+		'-c', $pgb_num_clients,
+		'-C',
+		'--exit-on-abort',
+		'-f', $script_file,
+		'postgres'
+	],
+	'<'  => \$scan_stdin,
+	'>'  => \$scan_stdout,
+	'2>' => \$scan_stderr
+);
+ok($scan_process, "pgbench buffercache scan (read) started successfully");
+
+# Allow pgbench to establish connections and start generating load.
+sleep(1);
+
+# Resize buffer pool to various sizes while both pgbench workloads are running.
+# Small sizes induce frequent buffer eviction and allocation; sizes near
+# max_shared_buffers stress the upper boundary.
+my $tests_completed = 0;
+my @buffer_sizes = (32, 24, 29, 40, 29, 20, 16, 150, 80, 24);
+for my $target_size (@buffer_sizes)
+{
+	# Convert number of buffers to a string that will be reported by SHOW
+	# shared_buffers. This simple calculation works for sizes smaller than 128
+	# beyond which the unit changes to MB.
+	$target_size = $target_size * 8;
+	$target_size = $target_size . 'kB';
+
+	# Verify both workload generators are still running
+	if (!$write_process->pumpable) {
+		ok(0, "pgbench TPC-B is still running during resize to $target_size");
+		last;
+	}
+	if (!$scan_process->pumpable) {
+		ok(0, "pgbench scan is still running during resize to $target_size");
+		last;
+	}
+	
+	apply_and_verify_buffer_change($node, $target_size);
+	$tests_completed++;
+	
+	# Wait for the resized buffer pool to stabilize. If the resized buffer pool
+	# is utilized fully, it might hit any wrongly initialized areas of shared
+	# memory.
+	sleep(2);
+}
+is($tests_completed, scalar(@buffer_sizes), "All buffer sizes were tested");
+
+# Verify pg_buffercache count matches the final resize target.
+# Last target: 24 buffers (192kB).
+my $expected_buffers = 24;
+is($node->safe_psql('postgres', "SELECT count(*) FROM pg_buffercache"),
+	$expected_buffers,
+	"pg_buffercache count matches final buffer pool size ($expected_buffers)");
+
+# Shut down both pgbench processes.
+for my $proc ($write_process, $scan_process) {
+	if ($proc->pumpable) {
+		$proc->signal('TERM');
+	}
+	IPC::Run::finish $proc;
+}
+ok(grep({ $write_process->result == $_ } (0, 15)),
+	"pgbench TPC-B exited gracefully");
+ok(grep({ $scan_process->result == $_ } (0, 15)),
+	"pgbench scan exited gracefully");
+
+# Log any error output from pgbench for debugging.
+diag("pgbench TPC-B stderr:\n$write_stderr");
+diag("pgbench scan stderr:\n$scan_stderr");
+
+# Ensure database is still functional after all the buffer changes
+$node->connect_ok("dbname=postgres", 
+	"Database remains accessible after $tests_completed buffer resize operations");
+
+done_testing();

--- a/contrib/pg_buffercache/t/001_stress.pl
+++ b/contrib/pg_buffercache/t/001_stress.pl
@@ -1,179 +1,76 @@
 # Copyright (c) 2025-2025, PostgreSQL Global Development Group
 #
-# Stress test for shared_buffer resizing under concurrent read and write load.
-# Runs pgbench TPC-B (writes) and pg_buffercache scans (reads) while resizing
-# the buffer pool through a range of sizes including near the maximum.
+# Stress test for pg_buffercache scans during concurrent shared buffer
+# pool resizing.
 
 use strict;
 use warnings;
-use File::Basename;
-use IPC::Run;
 use PostgreSQL::Test::Cluster;
-use PostgreSQL::Test::Utils;
 use Test::More;
 
-# Function to resize buffer pool and verify the change.
-sub apply_and_verify_buffer_change
-{
-	my ($node, $new_size) = @_;
-	
-	# Use the new pg_resize_shared_buffers() interface which handles everything synchronously
-	$node->safe_psql('postgres', "ALTER SYSTEM SET shared_buffers = '$new_size'");
-	$node->safe_psql('postgres', "SELECT pg_reload_conf()");
-	
-	# If resize function fails, try a few times before giving up
-	my $max_retries = 5;
-	my $retry_delay = 1; # seconds
-	my $success = 0;
-	for my $attempt (1..$max_retries) {
-		my $result = $node->safe_psql('postgres', "SELECT pg_resize_shared_buffers()");
-		if ($result eq 't') {
-			$success = 1;
-			last;
-		}
-		
-		# If not the last attempt, wait before retrying
-		if ($attempt < $max_retries) {
-			note "Resizing buffer pool to $new_size, attempt $attempt failed, retrying after $retry_delay seconds...";
-			sleep($retry_delay);
-		}
-	}
-	
-	is($success, 1, 'resizing to ' . $new_size . ' succeeded after retries');
-	is($node->safe_psql('postgres', "SHOW shared_buffers"), $new_size,
-		'SHOW after resizing to '. $new_size . ' succeeded');
-}
-
-# Initialize a cluster and start pgbench in the background for concurrent load.
-my $node = PostgreSQL::Test::Cluster->new('main');
+my $node = PostgreSQL::Test::Cluster->new('stress');
 $node->init;
 
-# Permit resizing up to 160 buffers (1280kB) and start with 16 buffers (128kB).
 $node->append_conf('postgresql.conf', qq{
 max_shared_buffers = 160
 shared_buffers = 16
+restart_after_crash = off
 log_statement = none
 });
 
 $node->start;
 $node->safe_psql('postgres', "CREATE EXTENSION pg_buffercache");
-my $pgb_scale = 1;
-my $pgb_duration = 40;
-my $pgb_num_clients = 3;
+
 $node->pgbench(
-	"--initialize --init-steps=dtpvg --scale=$pgb_scale --quiet",
+	"--initialize --init-steps=dtpvg --scale=1 --quiet",
 	0,
 	[qr{^$}],
-	[   # stderr patterns to verify initialization stages
-		qr{dropping old tables},
-		qr{creating tables},
-		qr{done in \d+\.\d\d s }
-	],
-	"pgbench initialization (scale=$pgb_scale)"
-);
+	[qr{dropping old tables}, qr{creating tables},
+	 qr{done in \d+\.\d\d s }],
+	"pgbench init");
 
-# Start pgbench with default TPC-B workload for write-heavy load (dirty buffers,
-# WAL, checkpointing).  Use -C to create new connections during resize and
-# --exit-on-abort to stop on server crash.
-my ($write_stdin, $write_stdout, $write_stderr) = ('', '', '');
-my $write_process = IPC::Run::start(
-	[
-		'pgbench',
-		'-p', $node->port,
-		'-T', $pgb_duration,
-		'-c', $pgb_num_clients,
-		'-C',
-		'--exit-on-abort',
-		'postgres'
-	],
-	'<'  => \$write_stdin,
-	'>'  => \$write_stdout,
-	'2>' => \$write_stderr
-);
-ok($write_process, "pgbench TPC-B (write) started successfully");
+$node->pgbench(
+	'--no-vacuum --client=10 --transactions=500 -C '
+	  . '-b tpcb-like@5',
+	0,
+	[qr{actually processed}],
+	[qr{^$}],
+	'concurrent writes, scans, and resizes',
+	{
+		'buffercache_scan@10' => q{
+			SELECT count(*) FROM pg_buffercache;
+		},
+		'resize@2' => q{
+			\set nbuf random(16, 150)
+			ALTER SYSTEM SET shared_buffers = :nbuf;
+			SELECT pg_reload_conf();
+			SELECT pg_sleep(0.01);
+			SELECT pg_resize_shared_buffers();
+		},
+	});
 
-# Start a second pgbench with pg_buffercache scans for read-only load that
-# exercises the buffer descriptor array during resize.
-my ($scan_stdin, $scan_stdout, $scan_stderr) = ('', '', '');
-my $script_file = dirname(__FILE__) . '/../sql/buffercache_scan.sql';
-my $scan_process = IPC::Run::start(
-	[
-		'pgbench',
-		'-p', $node->port,
-		'-T', $pgb_duration,
-		'-c', $pgb_num_clients,
-		'-C',
-		'--exit-on-abort',
-		'-f', $script_file,
-		'postgres'
-	],
-	'<'  => \$scan_stdin,
-	'>'  => \$scan_stdout,
-	'2>' => \$scan_stderr
-);
-ok($scan_process, "pgbench buffercache scan (read) started successfully");
+my $final_buffers = 24;
+my $final_size = ($final_buffers * 8) . 'kB';
+$node->safe_psql('postgres',
+	"ALTER SYSTEM SET shared_buffers = '$final_size'");
+$node->safe_psql('postgres', "SELECT pg_reload_conf()");
+my $resized = $node->safe_psql('postgres',
+	"SELECT pg_resize_shared_buffers()");
+is($resized, 't', "final resize to $final_size succeeded");
 
-# Allow pgbench to establish connections and start generating load.
-sleep(1);
+is($node->safe_psql('postgres', "SHOW shared_buffers"),
+	$final_size,
+	"SHOW confirms final resize to $final_size");
 
-# Resize buffer pool to various sizes while both pgbench workloads are running.
-# Small sizes induce frequent buffer eviction and allocation; sizes near
-# max_shared_buffers stress the upper boundary.
-my $tests_completed = 0;
-my @buffer_sizes = (32, 24, 29, 40, 29, 20, 16, 150, 80, 24);
-for my $target_size (@buffer_sizes)
-{
-	# Convert number of buffers to a string that will be reported by SHOW
-	# shared_buffers. This simple calculation works for sizes smaller than 128
-	# beyond which the unit changes to MB.
-	$target_size = $target_size * 8;
-	$target_size = $target_size . 'kB';
-
-	# Verify both workload generators are still running
-	if (!$write_process->pumpable) {
-		ok(0, "pgbench TPC-B is still running during resize to $target_size");
-		last;
-	}
-	if (!$scan_process->pumpable) {
-		ok(0, "pgbench scan is still running during resize to $target_size");
-		last;
-	}
-	
-	apply_and_verify_buffer_change($node, $target_size);
-	$tests_completed++;
-	
-	# Wait for the resized buffer pool to stabilize. If the resized buffer pool
-	# is utilized fully, it might hit any wrongly initialized areas of shared
-	# memory.
-	sleep(2);
-}
-is($tests_completed, scalar(@buffer_sizes), "All buffer sizes were tested");
-
-# Verify pg_buffercache count matches the final resize target.
-# Last target: 24 buffers (192kB).
-my $expected_buffers = 24;
 is($node->safe_psql('postgres', "SELECT count(*) FROM pg_buffercache"),
-	$expected_buffers,
-	"pg_buffercache count matches final buffer pool size ($expected_buffers)");
+	$final_buffers,
+	"pg_buffercache count matches final size ($final_buffers buffers)");
 
-# Shut down both pgbench processes.
-for my $proc ($write_process, $scan_process) {
-	if ($proc->pumpable) {
-		$proc->signal('TERM');
-	}
-	IPC::Run::finish $proc;
-}
-ok(grep({ $write_process->result == $_ } (0, 15)),
-	"pgbench TPC-B exited gracefully");
-ok(grep({ $scan_process->result == $_ } (0, 15)),
-	"pgbench scan exited gracefully");
+my $rows = $node->safe_psql('postgres',
+	"SELECT count(*) FROM pgbench_accounts");
+cmp_ok($rows, '>', 0, "pgbench_accounts still readable after stress");
 
-# Log any error output from pgbench for debugging.
-diag("pgbench TPC-B stderr:\n$write_stderr");
-diag("pgbench scan stderr:\n$scan_stderr");
-
-# Ensure database is still functional after all the buffer changes
-$node->connect_ok("dbname=postgres", 
-	"Database remains accessible after $tests_completed buffer resize operations");
+$node->connect_ok("dbname=postgres",
+	"database accessible after stress test");
 
 done_testing();


### PR DESCRIPTION
Add a TAP test (001_stress.pl) that exercises pg_buffercache scans concurrent with shared buffer pool resizing. The test runs two pgbench workloads in parallel:

1. Default TPC-B (writes) - generates dirty buffers, WAL, and checkpoint activity during resize operations.
2. Custom buffercache scan script - repeatedly runs SELECT count(*) FROM pg_buffercache to stress buffer descriptor array access during resize.

The resize loop cycles through various buffer pool sizes including near the maximum (150 out of 160 buffers) to stress upper boundary behavior. After all resizes, the test verifies the pg_buffercache count matches the final buffer pool size.

Also adds sql/buffercache_scan.sql as the custom pgbench script and updates Makefile/meson.build to enable TAP tests.